### PR TITLE
Unstable channel ids

### DIFF
--- a/internal/pong/pong.go
+++ b/internal/pong/pong.go
@@ -50,3 +50,18 @@ func (p *Pong) Leaderboard(channelID string) ([]Player, error) {
 
 	return players, nil
 }
+
+func (p *Pong) UpdateChannelID(oldID, newID string) error {
+	query := `
+	UPDATE players
+	SET channel_id = $1
+	WHERE channel_id = $2
+	`
+
+	_, err := p.db.Exec(query, newID, oldID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -88,17 +88,29 @@ func (s *Server) command(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) event(w http.ResponseWriter, r *http.Request) {
-	var outerEvent EventRequest
-	if err := json.NewDecoder(r.Body).Decode(&outerEvent); err != nil {
+	var request EventRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		fmt.Printf("err: %v\n", err)
 		return
 	}
 
-	if outerEvent.Type == "url_verification" {
+	if request.Type == "url_verification" {
 		w.Header().Set("Content-Type", "text/plain")
-		w.Write([]byte(outerEvent.Challenge))
+		w.Write([]byte(request.Challenge))
 		return
 	}
+
+	innerEvent := request.Event
+	var err error
+
+	switch innerEvent["type"] {
+	case "channel_id_changed":
+		err = s.pong.UpdateChannelID(innerEvent["old_channel_id"], innerEvent["new_channel_id"])
+	default:
+		err = fmt.Errorf("unrecognized event")
+	}
+
+	fmt.Printf("err: %v\n", err)
 }
 
 func (s *Server) formatLeaderboard(leaderboard []pong.Player) string {

--- a/internal/rest/types.go
+++ b/internal/rest/types.go
@@ -21,14 +21,14 @@ type CommandResponse struct {
 }
 
 type EventRequest struct {
-	Token          string      `json:"token"`
-	Challenge      string      `json:"challenge"`
-	TeamID         string      `json:"team_id"`
-	ApiAppID       string      `json:"api_app_id"`
-	Event          interface{} `json:"event"`
-	Type           string      `json:"type"`
-	Authorizations interface{} `json:"authorizations"`
-	EventContext   string      `json:"event_context"`
-	EventID        string      `json:"event_id"`
-	EventTime      string      `json:"event_time"`
+	Token          string            `json:"token"`
+	Challenge      string            `json:"challenge"`
+	TeamID         string            `json:"team_id"`
+	ApiAppID       string            `json:"api_app_id"`
+	Event          map[string]string `json:"event"`
+	Type           string            `json:"type"`
+	Authorizations interface{}       `json:"authorizations"`
+	EventContext   string            `json:"event_context"`
+	EventID        string            `json:"event_id"`
+	EventTime      string            `json:"event_time"`
 }


### PR DESCRIPTION
This PR implements handling of `channel_id_changed` event. If such an event occurs, all records in the DB containing the old channel ID are updated with the new channel ID.

In addition to the handling of `channel_id_changed` event, the PR implements handling of `url_verification` event which is a single-fired event used to verify the URL set for event subscriptions.